### PR TITLE
Streaming support for S3 uploads

### DIFF
--- a/examples/amazon/s3/put-object-streaming.js
+++ b/examples/amazon/s3/put-object-streaming.js
@@ -1,7 +1,7 @@
 var inspect = require('eyes').inspector();
-var awssum = require('./awssum');
-var amazon = awssum.load('./amazon/amazon');
-var s3Service = awssum.load('./amazon/s3');
+var awssum = require('awssum');
+var amazon = awssum.load('amazon/amazon');
+var s3Service = awssum.load('amazon/s3');
 var fs = require('fs');
 
 var accessKeyId = process.env.ACCESS_KEY_ID;

--- a/lib/amazon/s3-config.js
+++ b/lib/amazon/s3-config.js
@@ -263,25 +263,31 @@ function bodyCompleteMultipartUpload(options, args) {
     return data2xml('CompleteMultipartUpload', data);
 }
 
+function extrasContentLength(options, args) {
+    var self = this;
+    
+    // add the Content-Length header we need
+    options.headers['Content-Length'] = args.ContentLength || options.body.length;
+}
+
 function extrasContentMd5(options, args) {
     var self = this;
 
-    // get the MD5 of the body
-    var md5 = crypto
-        .createHash('md5')
-        .update(options.body)
-        .digest('base64');
-
-    // add the two Content-* headers we need
-    options.headers['Content-MD5'] = md5;
-    options.headers['Content-Length'] = options.body.length;
-}
-
-function extrasContentLength(options, args) {
-    var self = this;
-
-    // add the Content-Length header we need
-    options.headers['Content-Length'] = options.body.length;
+	if(typeof options.body == "string" && !args.ContentMD5) {
+		// get the MD5 of the body
+		var md5 = crypto
+			.createHash('md5')
+			.update(options.body)
+			.digest('base64');
+	
+		// add the Content-MD5 header we need
+		options.headers['Content-MD5'] = md5;
+    }
+    else if (args.ContentMD5) {
+    	options.headers['Content-MD5'] = args.ContentMD5;
+    }
+    // add the Content-Length header
+    extrasContentLength(options, args) 
 }
 
 function extrasCopySource(options, args) {
@@ -1054,7 +1060,7 @@ module.exports = {
                 type     : 'body',
             },
         },
-        addExtras : extrasContentLength,
+        addExtras : extrasContentMd5,
         extractBody : 'none',
     },
 

--- a/lib/awssum.js
+++ b/lib/awssum.js
@@ -398,6 +398,10 @@ AwsSum.prototype.send = function(operation, args, callback) {
         if ( typeof operation.body === 'string' ) {
             options.body = operation.body;
         }
+        // if it's a readable stream (either native or custom)
+        else if( operation.body && typeof operation.body.pipe == "function" && body.readable) {
+            options.bodyStream = operation.body;
+        }
         else if ( typeof operation.body === 'function' ) {
             options.body = operation.body.apply(self, [ options, args ]);
         }
@@ -646,7 +650,13 @@ AwsSum.prototype.request = function(options, callback) {
     if ( ! _.isUndefined(options.body) ) {
         req.write(options.body);
     }
-    req.end();
+    
+    if( options.bodyStream ) {
+    	req.pipe(options.bodyStream); // automatically calls req.end()
+    } 
+    else {
+	    req.end();
+    }
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/lib/awssum.js
+++ b/lib/awssum.js
@@ -328,7 +328,7 @@ AwsSum.prototype.send = function(operation, args, callback) {
 
     // ---
 
-    // build all of the params and headers
+    // build all of the params and headers, and copy the body if user-supplied
     options.params = [];
     options.headers = {};
     options.forms = [];
@@ -393,14 +393,10 @@ AwsSum.prototype.send = function(operation, args, callback) {
 
     // ---
 
-    // build the body (if defined)
+    // build the body (if defined in the operation rather than as a required attribute)
     if ( operation.body ) {
         if ( typeof operation.body === 'string' ) {
             options.body = operation.body;
-        }
-        // if it's a readable stream (either native or custom)
-        else if( operation.body && typeof operation.body.pipe == "function" && body.readable) {
-            options.bodyStream = operation.body;
         }
         else if ( typeof operation.body === 'function' ) {
             options.body = operation.body.apply(self, [ options, args ]);
@@ -610,6 +606,7 @@ AwsSum.prototype.request = function(options, callback) {
         host    : options.host,
         path    : options.path,
         headers : options.headers,
+        port    : options.port // to make testing easier
     };
 
     if ( options.params.length ) {
@@ -646,17 +643,25 @@ AwsSum.prototype.request = function(options, callback) {
         callback(err, null);
     });
 
-    // tell the request it's over (but also pass the body if we have it)
-    if ( ! _.isUndefined(options.body) ) {
-        req.write(options.body);
-    }
     
-    if( options.bodyStream ) {
-    	req.pipe(options.bodyStream); // automatically calls req.end()
+	if(options.body && typeof options.body.pipe == "function" && options.body.readable) {
+    	// if the body is a readableStream, pipe it. (pipe automatically ends the request)
+    	options.body.pipe(req);
+    	options.body.on('error', function(err){
+    		callback(err, null);
+    		req.end(); // todo: determine if this is necessary
+    	});
     } 
     else {
+    	// send the body if there is one, then end the request
+    	if ( ! _.isUndefined(options.body) ) {
+    		console.log('sending body');
+			req.write(options.body);
+		}
+		console.log('ending req');
 	    req.end();
-    }
+	}
+
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/lib/put-object-streaming.js
+++ b/lib/put-object-streaming.js
@@ -1,0 +1,45 @@
+var inspect = require('eyes').inspector();
+var awssum = require('./awssum');
+var amazon = awssum.load('./amazon/amazon');
+var s3Service = awssum.load('./amazon/s3');
+var fs = require('fs');
+
+var accessKeyId = process.env.ACCESS_KEY_ID;
+var secretAccessKey = process.env.SECRET_ACCESS_KEY;
+var awsAccountId = process.env.AWS_ACCOUNT_ID;
+var bucket = process.env.S3_BUCKET;
+
+var s3 = new s3Service(accessKeyId, secretAccessKey, awsAccountId, amazon.US_EAST_1);
+
+console.log( 'Region :', s3.region() );
+console.log( 'EndPoint :',  s3.host() );
+console.log( 'AccessKeyId :', s3.accessKeyId() );
+console.log( 'SecretAccessKey :', s3.secretAccessKey().substr(0,3) + "..." );
+console.log( 'AwsAccountId :', s3.awsAccountId() );
+console.log( 'S3Bucket :', bucket );
+
+var path_to_file = __filename; // __filename is this js file
+
+// you must run fs.stat to get the file size for the content-length header (s3 requires this)
+fs.stat(path_to_file, function(err, file_info) {
+
+	if (err) {
+		inspect(err, 'Error reading file');
+		return;
+	}
+	
+	var bodyStream = fs.createReadStream( path_to_file );
+
+	var options = {
+		BucketName    : bucket,
+		ObjectName    : 'test-object.txt',
+		ContentLength : file_info.size,
+		Body          : bodyStream
+	};
+	
+	s3.PutObject(options, function(err, data) {
+		console.log("\nputting an object to " + bucket + " - expecting success");
+		inspect(err, 'Error');
+		inspect(data, 'Data');
+	});
+});

--- a/test/s3-streaming.js
+++ b/test/s3-streaming.js
@@ -1,0 +1,34 @@
+// ---------------------------------------------------------
+//
+// s3-streaming.js - test for streaming uploads to s3
+//
+// Copyright (c) 2012 Nathan Friedly - http://nfriedly.com
+//
+// License: http://opensource.org/licenses/MIT
+//
+// ---------------------------------------------------------
+
+
+var tap = require("tap"),
+	_ = require('underscore'),
+	test = tap.test,
+	plan = tap.plan;
+var awssum = require('../'),
+	amazon = awssum.load('amazon/amazon'),
+	s3service = awssum.load('amazon/s3');
+
+var options = {
+	BucketName: "asdf",
+	ObjectName: "asdf",
+	ContentLength: 2,
+	BodyStream: {on: function(){}, readable: true}
+};
+
+test("AwsSum.prototype.send accepts a request with a bodyStream instead of a body", function(t) {
+	t.plan(1);
+	var s3 = new s3service("key","secret","account_id",amazon.US_EAST_1);
+	s3.request = function() { t.ok(true, "AweSum.prototype.request called"); }
+	s3.putObject(options, function(err, data) {
+		t.notOk(err, "putObject callback fired with error");
+	});
+});

--- a/test/s3-streaming.js
+++ b/test/s3-streaming.js
@@ -8,11 +8,10 @@
 //
 // ---------------------------------------------------------
 
-
-var tap = require("tap"),
-	_ = require('underscore'),
-	test = tap.test,
-	plan = tap.plan;
+var http = require('http'),
+	https = require('https'),
+	fs = require('fs');
+var test = require("tap").test;
 var awssum = require('../'),
 	amazon = awssum.load('amazon/amazon'),
 	s3service = awssum.load('amazon/s3');
@@ -31,4 +30,65 @@ test("AwsSum.prototype.send accepts a request with a bodyStream instead of a bod
 	s3.putObject(options, function(err, data) {
 		t.notOk(err, "putObject callback fired with error");
 	});
+});
+
+// fake self-signed cert and private key
+var SSL_CERT = "-----BEGIN CERTIFICATE-----\n" + 
+"MIIBfDCCASYCCQDQ1TLT4mhJWDANBgkqhkiG9w0BAQUFADBFMQswCQYDVQQGEwJV\n" + 
+"UzETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0\n" + 
+"cyBQdHkgTHRkMB4XDTEyMDMyMjA0NTAyN1oXDTEyMDQyMTA0NTAyN1owRTELMAkG\n" + 
+"A1UEBhMCVVMxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0\n" + 
+"IFdpZGdpdHMgUHR5IEx0ZDBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQDGdrVT6h1o\n" + 
+"gK5de1D/Ef391nlu10EO1WOw58N3HJnyrE0D4/q1AoFww0YV5pvRdiJSyxZeD2cl\n" + 
+"+m9dfBnE2leDAgMBAAEwDQYJKoZIhvcNAQEFBQADQQBsaWZVQY2D/0jcRA7eZBA1\n" + 
+"JUU/jVasS7RraRKE3VeSsxL8P4WCCk0jDeIcFzZsSYgqfG7wCwwMZGG315qE5m1S\n" + 
+"-----END CERTIFICATE-----\n";
+
+var SSL_KEY = "-----BEGIN RSA PRIVATE KEY-----\n" + 
+"MIIBOwIBAAJBAMZ2tVPqHWiArl17UP8R/f3WeW7XQQ7VY7Dnw3ccmfKsTQPj+rUC\n" + 
+"gXDDRhXmm9F2IlLLFl4PZyX6b118GcTaV4MCAwEAAQJAfxZfMVg28seMYMJp8Jyl\n" + 
+"6Bmic08WExikmREgwzKmhpWbKK0Gx8xn3ZWjXPpdcKyA8J6p1rns0IQyDCZi+oZN\n" + 
+"IQIhAPlXD5x7DEpa9bL1FItTstWQ2s4bS8luuT0aDAVNdYfxAiEAy8PDuXKFJzTz\n" + 
+"63owC4gdb63zgzJpUGOfiTYOy74K6rMCIQCExpK+nlvOIJ/kG1REWV7LEWcjCDAU\n" + 
+"ZQzpd7xc+oGS0QIgYKHuaDwPOZC7PKktr8pVa2krWsTFfQJB3mhsi+MMelECIQCi\n" + 
+"YmwpCQIFgQeiZ4RBksM4BXwpqvKKKpwlLG7Ae9Sdrw==\n" + 
+"-----END RSA PRIVATE KEY-----\n";
+
+test("AwsSum.prototype.request properly streams body contents", function(t) {
+	t.plan(2);
+
+	// some "random" data
+	var REQUEST_BODY = "adsf " + SSL_CERT + "asdf " + SSL_KEY + "asdf"; 
+
+	var fakeServer = http.createServer(function(req, res) {
+		AwsSum.prototype.request({
+			host: localhost,
+			port: 3101,
+			path: "/",
+			headers: {},
+			bodyStream: req // http.ServerRequest is a Readable Stream
+		});
+	});
+	fakeServer.listen(3100);
+	var fakeS3 = https.createServer({key: SSL_KEY, cert: SSL_CERT}, function(req, res) {
+		t.ok(true, "fake s3 server called");
+		var data = ''; 
+		req.on('data', function(chunk) {
+			data += chunk.toString();
+		});
+		req.on('end', function() {
+			t.ok(data == REQUEST_BODY, "Body was uploaded successfully");
+		});
+	});
+	fakeRemoteServer.listen(3101);
+
+	// create a request to the fakeServer so that it will create a Readable Stream 
+	var fakeClient = http.request({
+		host: "localhost",
+		port: 3100,
+		path: "/",
+		method: "POST"
+	});
+	req.write(REQUEST_BODY);
+	req.end();
 });


### PR DESCRIPTION
Allows the body of an S3.PutObject() to be a ReadableStream. Includes tests and an example. Should work for most other services with little or no tweaking.

The only downside is that you must supply the content length, so it won't work for multipart/form-data uploads.

I also fixed a couple of bugs where content-length was being overridden in s3-config.js and content-md5 was being skipped but would have also overridden the user-supplied value. Now they both jump in, if possible, but do not nuke existing values.

This fixes issue #7.
