### PR TITLE
Fixed two bugs I added, an addExtras enhancement, updated example

### DIFF
--- a/examples/amazon/s3/put-object.js
+++ b/examples/amazon/s3/put-object.js
@@ -16,11 +16,13 @@ console.log( 'AccessKeyId :', s3.accessKeyId() );
 // console.log( 'SecretAccessKey :', s3.secretAccessKey() );
 console.log( 'AwsAccountId :', s3.awsAccountId() );
 
+var body = "Hello, World!\n";
+
 var options = {
     BucketName    : 'pie-18',
     ObjectName    : 'test-object.txt',
-    ContentLength : '14',
-    Body          : "Hello, World!\n",
+    ContentLength : Buffer.byteLength(body), // This is for strings. See put-object-streaming.js for a file example
+    Body          : body,
 };
 
 s3.PutObject(options, function(err, data) {

--- a/lib/amazon/s3-config.js
+++ b/lib/amazon/s3-config.js
@@ -295,13 +295,6 @@ function bodyCompleteMultipartUpload(options, args) {
     return data2xml('CompleteMultipartUpload', data);
 }
 
-function extrasContentLength(options, args) {
-    var self = this;
-    
-    // add the Content-Length header we need
-    options.headers['Content-Length'] = args.ContentLength || options.body.length;
-}
-
 function extrasContentMd5(options, args) {
     var self = this;
 
@@ -318,8 +311,6 @@ function extrasContentMd5(options, args) {
     else if (args.ContentMD5) {
     	options.headers['Content-MD5'] = args.ContentMD5;
     }
-    // add the Content-Length header
-    extrasContentLength(options, args) 
 }
 
 function extrasCopySource(options, args) {
@@ -1168,12 +1159,13 @@ module.exports = {
                 required : false,
                 type     : 'header',
             },
+            // If you body is a string, run Buffer.byteLength(options.body) to calculate this
             ContentLength : {
                 name     : 'Content-Length',
                 required : true,
                 type     : 'header',
             },
-            // set by the request after generating the XML
+            // Set automatically unless the body is a ReadableStream. 
             ContentMD5 : {
                 name     : 'Content-MD5',
                 required : false,
@@ -1216,7 +1208,7 @@ module.exports = {
                 type     : 'body',
             },
         },
-        addExtras : extrasContentMd5,
+        addExtras : extrasContentMd5, 
         // response
         extractBody : 'none',
     },

--- a/lib/amazon/s3-config.js
+++ b/lib/amazon/s3-config.js
@@ -295,6 +295,13 @@ function bodyCompleteMultipartUpload(options, args) {
     return data2xml('CompleteMultipartUpload', data);
 }
 
+function extrasContentLength(options, args) {
+    var self = this;
+    
+    // add the Content-Length header we need
+    options.headers['Content-Length'] = args.ContentLength || Buffer.byteLength( options.body );
+}
+
 function extrasContentMd5(options, args) {
     var self = this;
 
@@ -768,7 +775,7 @@ module.exports = {
             },
         },
         body : bodyLifecycleConfiguration,
-        addExtras : extrasContentMd5,
+        addExtras : [ extrasContentMd5, extrasContentLength ],
         // response
         extractBody : 'none',
     },

--- a/lib/awssum.js
+++ b/lib/awssum.js
@@ -424,13 +424,19 @@ AwsSum.prototype.send = function(operation, args, callback) {
 
     // add anything extra into the request
     var addExtras = operation.addExtras || self.addExtras;
-    if ( typeof addExtras === 'function' ) {
-        addExtras.apply(self, [ options, args ]);
+    if ( ! _.isArray(addExtras) ) {
+        addExtras = [addExtras];
     }
-    else {
-        // since this is a program error, we're gonna throw this one
-        throw 'Unknown addExtras : ' + typeof addExtras;
-    }
+    addExtras.forEach( function(extra) {
+        if ( typeof extra === 'function' ) {
+            extra.apply(self, [ options, args ]);
+        }
+        else {
+            // since this is a program error, we're gonna throw this one
+            throw 'Unknown addExtras : ' + typeof extra;
+        }
+    });
+    
 
     // finally, add the common operations
     self.addCommonOptions(options, args);
@@ -694,6 +700,11 @@ AwsSum.prototype.request = function(options, callback) {
             callback(err, null);
         });
     });
+    
+    // if there is an error with the formation of the request, call the callback
+    req.on('error', function(err) {
+        callback(err, null);
+    });
 
     // ---
 
@@ -704,7 +715,7 @@ AwsSum.prototype.request = function(options, callback) {
     }
 
     // if it's a string, send it and end it
-    if ( typeof options.body === 'string' ) {
+    if ( typeof options.body === 'string' || options.body instanceof Buffer) {
         req.write(options.body);
         req.end();
         return;

--- a/test/s3-streaming.js
+++ b/test/s3-streaming.js
@@ -83,8 +83,7 @@ var FAKE_S3_PORT = 3101;
  * In order to test with a "real" stream, we're creating a fake client and server. The client
  * uploads some data to the server, and the node "req" object passed to the server is a
  * ReadableStream containing that data. This ReadableStream is passed directly to
- * AwsSum.prototype.request as the bodyStream param.
- * Note: it should just be named "Body" when passing it to a proper api method like s3.PutObject()
+ * AwsSum.prototype.request as the body.
  * This test then sets up a fake s3 server to verify that the request() method properly copied the
  * streaming data to the s3 request. Because AweSum only allows for https requests, we've generated
  * a fake SSL key pair.


### PR DESCRIPTION
The primary reason for this is to fix the two bugs I introduced with my previous pull request:
- AwsSum.prototype.request once again properly handles errors on sending the request out
- It also once again accepts Buffers for the body. (This is useful for binary data.)

I didn't like how the only extra on `S3.PubObject` was the MD5 one which in turn called the content-length one. So I changed it to be an array containing both functions. Then I realized that it didn't matter because content-length was a required header so it would always go with the user-supplied one or else throw an error. But `S3.PutBucket` also needed both an MD5 and a Content-Length so I kept the changes.

I also changed `extrasContentLength` to use `Buffer.byteLength()` because both `string.length` and `buffer.length` can lead to incorrect content-length headers. It still won't work for non-string bodies, but it looks like it won't ever be called with a non-string body currently.

Lastly, I updated the s3 put-object example to use `Buffer.byteLength()` rather than have the content-length hard-coded and also commented to check the s3-streaming example for an example with a file.

So, in short, two bug fixes and a lot of junk :P
