### PR TITLE
add parameters to GetBucketObjectVersions

### DIFF
--- a/lib/amazon/s3-config.js
+++ b/lib/amazon/s3-config.js
@@ -631,6 +631,31 @@ module.exports = {
                 required : true,
                 type     : 'resource',
             },
+            Delimiter : {
+                name     : 'delimiter',
+                required : false,
+                type     : 'param',
+            },
+            KeyMarker : {
+                name     : 'key-marker',
+                required : false,
+                type     : 'param',
+            },
+            MaxKeys : {
+                name     : 'max-keys',
+                required : false,
+                type     : 'param',
+            },
+            Prefix : {
+                name     : 'prefix',
+                required : false,
+                type     : 'param',
+            },
+            VersionIdMarker : {
+                name     : 'version-id-marker',
+                required : false,
+                type     : 'param',
+            },
         },
     },
 

--- a/lib/amazon/s3-config.js
+++ b/lib/amazon/s3-config.js
@@ -1085,6 +1085,11 @@ module.exports = {
                 required : false,
                 type     : 'param',
             },
+            VersionId : {
+                name     : 'versionId',
+                required : false,
+                type     : 'param',
+            },
         },
         // response
         extractBody : 'blob',


### PR DESCRIPTION
GetBucketObjectVersions supports basically the same parameters as ListObjects (marker syntax is slightly different since it's a tuple now rather than a single key).

awssum didn't support the parameters, which I need...  so I added them.
