### PR TITLE
Error events on http request object are ignored

### DIFF
--- a/lib/awssum.js
+++ b/lib/awssum.js
@@ -697,6 +697,12 @@ AwsSum.prototype.request = function(options, callback) {
 
     // ---
 
+    // add error event handler
+    req.on('error', function(err) {
+        req.end(); // todo: determine if this is necessary
+        callback(err, null);
+    });
+
     // finally, if there is no body, just end the reques
     if ( _.isUndefined(options.body) ) {
         req.end();


### PR DESCRIPTION
I have an issue where it is needed to catch error events on request objects so I made this modification. I don't know if the `req.end` call is needed (cf. [this line](https://github.com/appsattic/node-awssum/blob/master/lib/awssum.js#L719)).
