### PR TITLE
Fixed issue with MD5 hashing of larger strings by using Buffers

### DIFF
--- a/lib/amazon/s3-config.js
+++ b/lib/amazon/s3-config.js
@@ -321,9 +321,11 @@ function extrasContentMd5(options, args) {
 
     if(typeof options.body === "string" && !args.ContentMD5) {
         // get the MD5 of the body
+        // Amazon hashes on a buffer, so convert body to match
+        var body = new Buffer(options.body);
         var md5 = crypto
             .createHash('md5')
-            .update(options.body)
+            .update(body)
             .digest('base64');
 
         // add the Content-MD5 header we need


### PR DESCRIPTION
The current implementation runs crypto's hashing on options.body as a string, which generates hashes different from Amazon for files larger than about 136000 bytes. I switched this so first converts options.body to a Buffer, which generates hashes consistent with Amazon.

I didn't change the example, since this happens internally, but it might be worth doing since someone could override the md5 hashing if they wanted to.
