### PR TITLE
Exporting US_WEST_2 to enable using the s3 instance in Northern Californ...

### DIFF
--- a/lib/amazon/amazon.js
+++ b/lib/amazon/amazon.js
@@ -189,6 +189,7 @@ Amazon.prototype.addSignature = function(options, signature) {
 // constants
 exports.US_EAST_1      = US_EAST_1;
 exports.US_WEST_1      = US_WEST_1;
+exports.US_WEST_2      = US_WEST_2;
 exports.EU_WEST_1      = EU_WEST_1;
 exports.AP_SOUTHEAST_1 = AP_SOUTHEAST_1;
 exports.AP_NORTHEAST_1 = AP_NORTHEAST_1;


### PR DESCRIPTION
I got some instances running in the Northern California data-center and would like to use the local S3, but the US_WEST_2 flag is currently not exported.
