### PR TITLE
Multiple-address A records.

### DIFF
--- a/lib/amazon/route53-config.js
+++ b/lib/amazon/route53-config.js
@@ -74,16 +74,15 @@ function bodyChangeResourceRecordSetsRequest(options, args) {
                 Type : change.Type,
                 TTL : change. Ttl,
                 ResourceRecords : {
-                    ResourceRecord : {
-                        Value : [],
-                    },
+                    ResourceRecord : [],
                 },
             },
         };
 
         // now add each resource record
         _.each(change.ResourceRecords, function(rr) {
-            c.ResourceRecordSet.ResourceRecords.ResourceRecord.Value.push(rr);
+            var value = { Value : rr };
+            c.ResourceRecordSet.ResourceRecords.ResourceRecord.push(value);
         });
 
         // push this onto the Change array


### PR DESCRIPTION
This change allows multiple-address A records to be created. The
problem was that the multiple addresses used to all get packed together
into a single `<ResourceRecord>` node, but the Route53 API expects them
to each get their own such node.

This is a proposed fix for issue #36.
