### PR TITLE
Fix Ex2.CreateTags

### DIFF
--- a/lib/amazon/ec2-config.js
+++ b/lib/amazon/ec2-config.js
@@ -544,7 +544,7 @@ module.exports = {
         args : {
             Action     : required,
             ResourceId : requiredArray,
-            Tag        : requiredData,
+            Tag        : { required : true, type : 'param-data', setName: 'Tag' },
         },
     },
 


### PR DESCRIPTION
With args {'ResourceId': ['i-instance], 'Tag': {'Key': ['Name'], 'Value': ['myname']}}

...I get a 200 back from Amazon.
