### PR TITLE
Fix 'VisbilityTimeout' typo in AWS SQS' ChangeMessageVisibility method

### DIFF
--- a/lib/amazon/sqs-config.js
+++ b/lib/amazon/sqs-config.js
@@ -85,7 +85,7 @@ module.exports = {
                 required : true,
                 type     : 'param',
             },
-            VisbilityTimeout : {
+            VisibilityTimeout : {
                 required : true,
                 type     : 'param',
             },


### PR DESCRIPTION
There is a typo in the ChangeMessageVisibility method in AWS SQS (missing an 'i'). This causes the method to fail (including when using the sample code provided) with the following error:

{ Code: 'AwsSumCheck', Message: 'Provide a VisbilityTimeout' }

This (small change) updates the parameter to 'VisibilityTimeout'.
