### PR TITLE
Include STS endpoints for all AWS regionnames

### DIFF
--- a/lib/amazon/sts.js
+++ b/lib/amazon/sts.js
@@ -31,6 +31,11 @@ var MARK = 'sts: ';
 // From: http://docs.amazonwebservices.com/general/latest/gr/rande.html
 var endPoint = {};
 endPoint[amazon.US_EAST_1]      = "sts.amazonaws.com";
+endPoint[amazon.US_WEST_1]      = "sts.amazonaws.com";
+endPoint[amazon.US_WEST_2]      = "sts.amazonaws.com";
+endPoint[amazon.EU_WEST_1]      = "sts.amazonaws.com";
+endPoint[amazon.AP_SOUTHEAST_1] = "sts.amazonaws.com";
+endPoint[amazon.AP_NORTHEAST_1] = "sts.amazonaws.com";
 endPoint[amazon.US_GOV_WEST_1]  = "sts.us-gov-west-1.amazonaws.com";
 
 var version = '2011-06-15';


### PR DESCRIPTION
This is required for cases where referring services (e.g., DynamoDB)
support more endpoints than the backing STS service.

---

This is an excellent library - thanks for putting it together.  I've been using it more than working through it, so if this PR isn't the proper way to solve the issue please do reject :)  My specific issue is trying to create DynamoDB records in us-west-1 which causes an exception when instantiating the Sts instance in dynamodb.js, line 59.  Cheers and thanks again.
