### PR TITLE
Amazon:RDS:ModifyDBInstance MasterUserPassword parameter is not required

### DIFF
--- a/lib/amazon/rds-config.js
+++ b/lib/amazon/rds-config.js
@@ -462,7 +462,7 @@ module.exports = {
             DBParameterGroupName       : optional,
             DBSecurityGroups           : optionalArray,
             EngineVersion              : optional,
-            MasterUserPassword         : required,
+            MasterUserPassword         : optional,
             MultiAZ                    : optional,
             OptionGroupName            : optional,
             PreferredBackupWindow      : optional,


### PR DESCRIPTION
Hey so I've only changed one parameter from one action in rds. This is just to get hang of everything. More to come soon
