### PR TITLE
Amazon:CloudFormation Action Parameter Type: 'optionalData' has been defined

### DIFF
--- a/lib/amazon/cloudformation-config.js
+++ b/lib/amazon/cloudformation-config.js
@@ -27,6 +27,7 @@
 var required      = { required : true,  type : 'param'       };
 var optional      = { required : false, type : 'param'       };
 var optionalArray = { required : false, type : 'param-array' };
+var optionalData  = { required : false, type : 'param-data',  prefix : 'member' };
 
 module.exports = {
 


### PR DESCRIPTION
When trying to call any CloudFormation action, a ReferenceError would be thrown, along the lines of:

<pre>node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
ReferenceError: optionalData is not defined
    at Object.<anonymous> (C:\dev\envLauncher\node_modules\awssum\lib\amazon\cloudformation-config.js:42:32)
    at Object.<anonymous> (C:\dev\envLauncher\node_modules\awssum\lib\amazon\cloudformation.js:24:18)
From previous event:
    at Object.launchWeekly (C:\dev\envLauncher\envLaunchy2.js:27:10)
    at Object.<anonymous> (C:\dev\envLauncher\envLaunchy2.js:437:12)</pre>


as you can see, the optionalData parameter type was not defined. I looked in a some of the other aws configs and then copied the definition for optionalData into couldformation-config.js
