### PR TITLE
Fix CloudFront CreateInvalidation

### DIFF
--- a/lib/amazon/cloudfront-config.js
+++ b/lib/amazon/cloudfront-config.js
@@ -715,7 +715,7 @@ module.exports = {
                 type     : 'special',
             },
         },
-        body : function(args) {
+        body : function(options, args) {
             var self = this;
             var data = {
                 Path : args.Path,


### PR DESCRIPTION
Looks like there was a simple typo that broke CreateInvalidation. This should fix that.
