### PR TITLE
GroupName and GroupId are conflicting options for DeleteSecurityGroup

### DIFF
--- a/lib/amazon/ec2-config.js
+++ b/lib/amazon/ec2-config.js
@@ -618,8 +618,8 @@ module.exports = {
         },
         args : {
             Action    : required,
-            GroupName : required,
-            GroupId   : required,
+            GroupName : optional,
+            GroupId   : optional,
         },
     },
 


### PR DESCRIPTION
I just made them both optional, but really there is a requirement for one or the other.
