### PR TITLE
Fix for AttributeName in SQS ReceiveMessage

### DIFF
--- a/lib/amazon/sqs-config.js
+++ b/lib/amazon/sqs-config.js
@@ -281,8 +281,9 @@ module.exports = {
                 type     : 'param',
             },
             AttributeName : {
-                required : false,
-                type      : 'param-array-set',
+                name:       'AttributeName.1',
+                required  : false,
+                type      : 'param',
             },
             MaxNumberOfMessages : {
                 required : false,

--- a/lib/amazon/sqs-config.js
+++ b/lib/amazon/sqs-config.js
@@ -282,7 +282,7 @@ module.exports = {
             },
             AttributeName : {
                 required : false,
-                type     : 'param-array-set',
+                type      : 'param-array-set',
             },
             MaxNumberOfMessages : {
                 required : false,


### PR DESCRIPTION
Currently AWS SQS ReceiveMessage fails if the client wants to get message metadata. This fixes it. Verified problem and fix using examples/amazon/sqs/receive-message.js
