### PR TITLE
Add WaitTimeSeconds parameter to AWS SQS ReceiveMessage action

### DIFF
--- a/lib/amazon/sqs-config.js
+++ b/lib/amazon/sqs-config.js
@@ -296,6 +296,10 @@ module.exports = {
                 required : true,
                 type : 'special',
             },
+            WaitTimeSeconds : {
+                required : false,
+                type     : 'param',
+            },
         },
     },
 


### PR DESCRIPTION
Support for this parameter was added in the 2012-11-05 API update.
