### PR TITLE
Add support for AWS Signature Version 4 for SQS

### DIFF
--- a/lib/amazon/sqs.js
+++ b/lib/amazon/sqs.js
@@ -22,6 +22,7 @@ var _ = require('underscore');
 var awssum = require('../awssum');
 var amazon = require('./amazon');
 var operations = require('./sqs-config');
+var awsSignatureV4 = require('./aws-signature-v4');
 
 // --------------------------------------------------------------------------------------------------------------------
 // package variables
@@ -78,6 +79,24 @@ Sqs.prototype.host = function() {
 Sqs.prototype.version = function() {
     return version;
 };
+
+// --------------------------------------------------------------------------------------------------------------------
+// AWS Signature v4
+
+Sqs.prototype.scope = function() {
+    return 'sqs';
+}
+
+Sqs.prototype.needsTarget = function() {
+    return false;
+}
+
+// This service uses the AWS Signature v4.
+Sqs.prototype.strToSign        = awsSignatureV4.strToSign;
+Sqs.prototype.signature        = awsSignatureV4.signature;
+Sqs.prototype.addSignature     = awsSignatureV4.addSignature;
+Sqs.prototype.addCommonOptions = awsSignatureV4.addCommonOptions;
+Sqs.prototype.contentType      = function() { return 'application/x-amz-json-1.0'; };
 
 // --------------------------------------------------------------------------------------------------------------------
 // operations on the service


### PR DESCRIPTION
The support was added to the service in the 2012-11-05 API update.
