### PR TITLE
DelaySeconds on sqs SendMessageBatch is no longer required.

### DIFF
--- a/lib/amazon/sqs-config.js
+++ b/lib/amazon/sqs-config.js
@@ -377,7 +377,7 @@ module.exports = {
                 setName   : 'SendMessageBatchRequestEntry',
             },
             DelaySeconds : {
-                required  : true,
+                required  : false,
                 type      : 'param-array-set',
                 setName   : 'SendMessageBatchRequestEntry',
             },


### PR DESCRIPTION
Updated to match the AWS documentation. 
