### PR TITLE
Added http option to dynamo DB

### DIFF
--- a/lib/amazon/dynamodb.js
+++ b/lib/amazon/dynamodb.js
@@ -61,6 +61,12 @@ var DynamoDB = function(opts) {
     // create an STS client to use for getting the session tokens
     self._sts = new Sts(opts);
 
+    if ( opts.protocol ) {
+        self.protocolOption = opts.protocol;
+    } else {
+        self.protocolOption = "https";
+    }
+
     return self;
 };
 
@@ -72,6 +78,10 @@ util.inherits(DynamoDB, amazon.Amazon);
 
 DynamoDB.prototype.method = function() {
     return 'POST';
+};
+
+DynamoDB.prototype.protocol = function() {
+    return this.protocolOption;
 };
 
 DynamoDB.prototype.host = function(args) {


### PR DESCRIPTION
You can now optionally specify 'protocol' in the options for the DynamoDB class as either http or https. This makes the requests significantly faster. 

I'm not too sure if this is consistent with the way you use optional parameters in other classes so feel free to reject. 
