### PR TITLE
Fixed RDS DescribeDBSubnetGroups argument requirements

### DIFF
--- a/lib/amazon/rds-config.js
+++ b/lib/amazon/rds-config.js
@@ -318,7 +318,7 @@ module.exports = {
         },
         args : {
             Action            : required,
-            DBSubnetGroupName : required,
+            DBSubnetGroupName : optional,
             Marker            : optional,
             MaxRecords        : optional,
         },


### PR DESCRIPTION
The DBSubnetGroupName argument for RDS DescribeDBSubnetGroups is optional if you want to receive a list of all DB subnets.
