### PR TITLE
Fixed Route53 CreateHostedZone Request

### DIFF
--- a/lib/amazon/route53-config.js
+++ b/lib/amazon/route53-config.js
@@ -99,6 +99,7 @@ module.exports = {
     CreateHostedZone : {
         url : 'http://docs.amazonwebservices.com/Route53/latest/APIReference/API_CreateHostedZone.html',
         method : 'POST',
+        statusCode: 201,
         path : pathHostedZone,
         args : {
             Name : {


### PR DESCRIPTION
Route 53 CreateHostedZone returns a 201 Created header code instead of the standard 200 OK, this was causing the call to return an error
