### PR TITLE
Allow user to pass in region for Amazon CloudSearch

### DIFF
--- a/lib/amazon/cloudsearch.js
+++ b/lib/amazon/cloudsearch.js
@@ -31,8 +31,8 @@ var MARK = 'cloudsearch: ';
 
 // From: http://docs.amazonwebservices.com/general/latest/gr/rande.html
 var endPoint = {};
-endPoint[amazon.US_EAST_1]      = "cloudsearch.us-east-1.amazonaws.com";
-// endPoint[amazon.US_WEST_1]      = "";
+// endPoint[amazon.US_EAST_1]      = "cloudsearch.us-east-1.amazonaws.com";
+endPoint[amazon.US_WEST_1]      = "";
 // endPoint[amazon.US_WEST_2]      = "";
 // endPoint[amazon.EU_WEST_1]      = "";
 // endPoint[amazon.AP_SOUTHEAST_1] = "";
@@ -110,7 +110,7 @@ var DocumentService = function(opts) {
     var self = this;
 
     // we only have one region for this service, so default it here
-    opts.region = amazon.US_EAST_1;
+    // opts.region = amazon.US_WEST_1;
 
     // check that we have each of these values
     if ( ! opts.domainName ) {
@@ -191,7 +191,8 @@ var SearchService = function(opts) {
     var self = this;
 
     // we only have one region for this service, so default it here
-    opts.region = amazon.US_EAST_1;
+
+    // Going to change these for our app
 
     // check that we have each of these values
     if ( ! opts.domainName ) {

--- a/lib/amazon/cloudsearch.js
+++ b/lib/amazon/cloudsearch.js
@@ -126,7 +126,7 @@ var DocumentService = function(opts) {
     // set the local vars so the functions below can close over them
     var domainName = opts.domainName;
     var domainId   = opts.domainId;
-    var region     = opts.region;
+    var region     = opts.region || US_EAST_1;
     self.domainName = function() { return domainName; };
     self.domainId   = function() { return domainId;   };
     self.region     = function() { return region;     };
@@ -208,7 +208,7 @@ var SearchService = function(opts) {
     // set the local vars so the functions below can close over them
     var domainName = opts.domainName;
     var domainId   = opts.domainId;
-    var region     = opts.region;
+    var region     = opts.region || US_EAST_1;
     self.domainName = function() { return domainName; };
     self.domainId   = function() { return domainId  ; };
     self.region     = function() { return region;     };


### PR DESCRIPTION
I noticed that when I create a DocumentService or SearchService for Amazon CloudSearch it would not work. I realized it's because I have the regian US_WEST_1. I changed it only for the DS and SS for now, and if user does not pass in a region it defaults to US_EAST_1.
