### PR TITLE
Allow custom port and path to be set as option

### DIFF
--- a/awssum.js
+++ b/awssum.js
@@ -305,6 +305,11 @@ var AwsSum = function(opts) {
         self._protocol = opts.protocol;
     }
 
+    // if we have been given a path, use that one
+    if ( opts.path ) {
+        self._path = opts.path;
+    }
+
     return self;
 };
 
@@ -326,6 +331,9 @@ AwsSum.prototype.method = function() {
 // AwsSum.prototype.host // no default
 
 AwsSum.prototype.path = function() {
+    if ( this._path ) {
+        return this._path;
+    }
     return '/';
 };
 

--- a/awssum.js
+++ b/awssum.js
@@ -281,6 +281,7 @@ function stringifyQuery(params) {
 // function protocol()             -> string (the default protocol for the HTTP request, https or http)
 // function method()               -> string (the default method for the HTTP request)
 // function host()                 -> string (the host for this service/region)
+// function port()                 -> number (the port for this service/region)
 // function path()                 -> string (the default path for this service)
 // function addExtras()            -> side effect, adds extra whatever
 // function addCommonOptions(options, args) -> side effect, adds the common headers/params for this service
@@ -305,6 +306,11 @@ var AwsSum = function(opts) {
         self._protocol = opts.protocol;
     }
 
+    // if we have been given a port, use that one
+    if ( opts.port ) {
+        self._port = opts.port;
+    }
+
     // if we have been given a path, use that one
     if ( opts.path ) {
         self._path = opts.path;
@@ -322,6 +328,18 @@ AwsSum.prototype.protocol = function() {
         return this._protocol;
     }
     return 'https';
+};
+
+AwsSum.prototype.port = function() {
+    var self = this;
+    if ( this._port ) {
+        return this._port;
+    }
+    if ( self.protocol() === 'http' ) {
+        return 80;
+    } else {
+        return 443;
+    }
 };
 
 AwsSum.prototype.method = function() {
@@ -507,6 +525,23 @@ AwsSum.prototype.send = function(operation, args, opts, callback) {
               throw 'Unknown operation.host : ' + typeof operation.host;
           }
       }
+    }
+
+    // ---
+
+    // build the port
+    options.port = self.port();
+    if ( operation.port) {
+        if ( typeof operation.port === 'function' ) {
+            options.port = operation.port.apply(self, [ options, args ]);
+        }
+        else if ( typeof operation.port === 'number' ) {
+            options.port = operation.port;
+        }
+        else {
+            // since this is a program error, we're gonna throw this one
+            throw 'Unknown operation.port : ' + typeof operation.port;
+        }
     }
 
     // ---
@@ -729,6 +764,7 @@ AwsSum.prototype.send = function(operation, args, opts, callback) {
         console.log('- method         : ', options.method);
         console.log('- protocol       : ', options.protocol);
         console.log('- host           : ', options.host);
+        console.log('- port           : ', options.port);
         console.log('- path           : ', options.path);
         console.log('- params         : ', options.params);
         console.log('- headers        : ', options.headers);
@@ -787,6 +823,7 @@ AwsSum.prototype.send = function(operation, args, opts, callback) {
             return;
           }
         }
+
         // save the whole result in here
         var result = {};
 
@@ -947,6 +984,7 @@ AwsSum.prototype.send = function(operation, args, opts, callback) {
 //
 // * options.method
 // * options.host
+// * options.port
 // * options.path
 // * options.params
 // * options.headers
@@ -964,6 +1002,7 @@ AwsSum.prototype.request = function(options, callback) {
     var reqOptions = {
         method  : options.method,
         host    : options.host,
+        port    : options.port,
         path    : options.path,
         headers : options.headers
     };

--- a/test/options.js
+++ b/test/options.js
@@ -13,14 +13,27 @@ test(function(t) {
     var awssum = new AwsSum({});
     var http = new AwsSum({
         protocol : 'http',
+        path : '/somepath',
+        port : 8080
     });
     var https = new AwsSum({
         protocol : 'https',
+        path : '/somepath',
+        port : 8443
     });
 
     t.equal('https', awssum.protocol(), 'Default is https');
     t.equal('http', http.protocol(), 'http works fine');
     t.equal('https', https.protocol(), 'https works fine');
+
+    t.equal(443, awssum.port(), 'Default is 443');
+    t.equal(8080, http.port(), 'http port works fine');
+    t.equal(8443, https.port(), 'https port works fine');
+
+    t.equal('/', awssum.path(), 'Default is "/"');
+    t.equal('/somepath', http.path(), 'http path works fine');
+    t.equal('/somepath', https.path(), 'https path works fine');
+
     t.end();
 });
 


### PR DESCRIPTION
Hi,

this little patch allows for custom port and custom path to be set as options to the service. 
I wrote it in order to use awssum libraries against third party services supporting the AWS EC2 API, like OpenStack, Eucalyptus etc. I am using it successfully with OpenStack as well as Amazon EC2.

It comes together with pull requests for awssum-amazon and awssum-amazon-ec2.  Support for awssum-amazon-s3 will follow soon.

Please review them and consider rolling them into the main distribution.

Thanks,
Giannis
